### PR TITLE
Fix nav drawer not reacting to clipping

### DIFF
--- a/template/src/App.vue
+++ b/template/src/App.vue
@@ -23,7 +23,7 @@
         </v-list-tile>
       </v-list>
     </v-navigation-drawer>
-    <v-toolbar fixed app>
+    <v-toolbar fixed app :clipped-left="clipped">
       <v-toolbar-side-icon @click.stop="drawer = !drawer" light></v-toolbar-side-icon>
       <v-btn
         icon


### PR DESCRIPTION
This is just a simple fix on the problem which the navigation drawer on the left is not responding correctly when it was set to clipped with the button in toolbar