### PR TITLE
Remove empty lines for ESLint

### DIFF
--- a/template/src/main.js
+++ b/template/src/main.js
@@ -2,7 +2,6 @@
 // The Vue build version to load with the `import` command
 // (runtime-only or standalone) has been set in webpack.base.conf with an alias.
 {{/if_eq}}
-
 import Vue from 'vue'{{#if_eq lintConfig "airbnb"}};{{/if_eq}}
 
 {{#alacarte}}


### PR DESCRIPTION
Removed the redundant empty lines. These empty lines may cause ESLint's linting error because of the rule  `no-multiple-empty-lines`.

In Vue's official template, there are no empty lines.
https://github.com/vuejs-templates/webpack/blob/664617f9245a30e61b87f9a439c611b223e6c17a/template/src/main.js#L4-L5