### PR TITLE
Update webpack.dev.config.js

### DIFF
--- a/template/build/webpack.dev.conf.js
+++ b/template/build/webpack.dev.conf.js
@@ -15,8 +15,8 @@ module.exports = merge(baseWebpackConfig, {
   module: {
     rules: utils.styleLoaders({ sourceMap: config.dev.cssSourceMap })
   },
-  // cheap-module-eval-source-map is faster for development
-  devtool: '#cheap-module-eval-source-map',
+  // cheap-module-eval-source-map is faster for development but doesn't allow breakpoints in VS Code.
+  devtool: '#eval-source-map',
   plugins: [
     new webpack.DefinePlugin({
       'process.env': config.dev.env


### PR DESCRIPTION
Use "eval-source-map" instead of "cheap-module-eval-source-map" devtool for generating sourcemaps. "cheap-module-eval-source-map" doesn't provide enough data for VS Code to support breakpoints. This will save many users of this template a lot of time, especially non-expert webpack users.

See:
https://github.com/Microsoft/vscode-chrome-debug-core/issues/83

Also of note, the root of this fork has gone back to using "eval-source-map" already:
https://github.com/vuejs-templates/webpack/commit/5b5909502f62e8b54f216bc03f65c315f373bf81